### PR TITLE
fix: Use correct variable for impressum link path

### DIFF
--- a/md2json2/src/main.rs
+++ b/md2json2/src/main.rs
@@ -3821,7 +3821,7 @@ fn render_index_html(
     let special_about_path = get_string(meta, lang, "special-about-path")?;
     let special_about_title = get_string(meta, lang, "special-about-title")?;
     index_html = index_html.replace("$$SPECIAL_ABOUT_TITLE$$", &special_about_title);
-    index_html = index_html.replace("$$SPECIAL_ABOUT_PATH$$", &special_about_title);
+    index_html = index_html.replace("$$SPECIAL_ABOUT_PATH$$", &special_about_path);
 
     index_html = index_html.replace("<!-- MULTILANG_TAGS -->", multilang);
     index_html = index_html.replace("$$SKIP_TO_MAIN_CONTENT$$", "Skip to main content");


### PR DESCRIPTION
In `render_index_html`, the `special_about_title` variable was used to replace the `$$SPECIAL_ABOUT_PATH$$` placeholder, resulting in an incorrect link for the impressum page in the footer of language-specific index pages.

This commit corrects the line to use the `special_about_path` variable, ensuring the link points to the correct lowercase path as defined in `config/meta.json`.