### PR TITLE
feat: Update build process and UI for WIP and docs

### DIFF
--- a/md2json2/src/docs.rs
+++ b/md2json2/src/docs.rs
@@ -160,7 +160,7 @@ pub fn document2html(
     
     let html = HTML.replace(
         "<!-- HEAD_TEMPLATE_HTML -->",
-        &head(doc, lang, &title_id, meta)?,
+        &head(doc, lang, &title_id, meta, true, author, slug)?,
     );
     let html = html.replace(
         "<!-- HEADER_NAVIGATION -->",

--- a/md2json2/src/main.rs
+++ b/md2json2/src/main.rs
@@ -2052,6 +2052,9 @@ fn head(
     lang: &str,
     title_id: &str,
     meta: &MetaJson,
+    is_doc: bool,
+    author: &str,
+    slug: &str,
 ) -> Result<String, String> {
     let license = include_str!("../../templates/license.html");
     let darklight = include_str!("../../templates/darklight.html");
@@ -2111,7 +2114,74 @@ fn head(
         &get_string(meta, lang, "page-smc")?,
     );
     head = head.replace("$$CONTACT_URL$$", &get_special_page_link(lang, "about", meta)?);
-    head = head.replace("$$SLUG$$", title_id);
+    head = head.replace("$$SLUG$$", slug);
+
+    let (pdf_path, md_path) = if is_doc {
+        let docs_folder = get_string(meta, lang, "special-docs-path").unwrap_or_default();
+        (
+            format!("/{}/{}/{}/{}.pdf", lang, docs_folder, author, slug),
+            format!("/{}/{}/{}/{}.md", lang, docs_folder, author, slug),
+        )
+    } else {
+        (
+            format!("/{}/{}.pdf", lang, slug),
+            format!("/{}/{}.md", lang, slug),
+        )
+    };
+
+    let toolbar_html = format!(
+        r#"
+        <style>
+            .article-toolbar {{
+                position: fixed;
+                top: 10px;
+                right: 10px;
+                display: flex;
+                flex-direction: column;
+                gap: 10px;
+                z-index: 1000;
+            }}
+            .toolbar-button {{
+                background-color: #f0f0f0;
+                border: 1px solid #ccc;
+                border-radius: 5px;
+                padding: 5px 10px;
+                cursor: pointer;
+                font-size: 1.2em;
+                display: flex;
+                align-items: center;
+                gap: 5px;
+            }}
+            .toolbar-button:hover {{
+                background-color: #e0e0e0;
+            }}
+        </style>
+        <div class="article-toolbar">
+            <a href="{}" target="_blank" class="toolbar-button" title="Download PDF">
+                &#x1F4C4;
+            </a>
+            <button class="toolbar-button" onclick="copyMarkdownToClipboard('{}')" title="Copy Article to Clipboard">
+                &#x1F4CB;
+            </button>
+        </div>
+        <script>
+            function copyMarkdownToClipboard(url) {{
+                fetch(url)
+                    .then(response => response.text())
+                    .then(text => {{
+                        navigator.clipboard.writeText(text).then(() => {{
+                            alert('Article copied to clipboard!');
+                        }}, () => {{
+                            alert('Failed to copy article to clipboard.');
+                        }});
+                    }});
+            }}
+        </script>
+        "#,
+        pdf_path, md_path
+    );
+
+    head = head.replace("<!-- ARTICLE_TOOLBAR -->", &toolbar_html);
 
     Ok(head)
 }
@@ -3006,7 +3076,7 @@ fn article2html(
     let a = &a;
     let html = HTML.replace(
         "<!-- HEAD_TEMPLATE_HTML -->",
-        &head(a, lang, title_id.as_str(), meta)?,
+        &head(a, lang, title_id.as_str(), meta, false, "", slug)?,
     );
     let html = html.replace(
         "<!-- HEADER_NAVIGATION -->",
@@ -4034,6 +4104,14 @@ fn main() -> Result<(), String> {
                 let html = docs::document2html(lang, author, slug, doc, &meta_map)?;
                 let output_path = output_dir.join(format!("{}.html", slug));
                 let _ = std::fs::write(output_path, &minify(&html));
+
+                match pdf::generate_pdf(doc) {
+                    Ok(pdf_bytes) => {
+                        let pdf_path = output_dir.join(format!("{}.pdf", slug));
+                        let _ = std::fs::write(pdf_path, pdf_bytes);
+                    }
+                    Err(e) => warnings.push(e),
+                }
             }
         }
     }

--- a/md2json2/src/wip.rs
+++ b/md2json2/src/wip.rs
@@ -18,9 +18,12 @@ pub fn generate_wip_page(
 
     for (lang, articles) in &all_articles.map {
         for (slug, article) in articles {
+            if article.is_prayer() {
+                continue;
+            }
             // WIP articles are rendered in a special wip/ subdirectory
             let link = SectionLink {
-                slug: format!("{}/{}/wip/{}.html", wip_url_base, lang, slug),
+                slug: format!("{}/{slug}", lang, slug = slug),
                 title: article.title.clone(),
                 id: None,
             };
@@ -57,9 +60,17 @@ pub fn generate_wip_page(
         if items.is_empty() { return String::new(); }
         let list_items = items
             .iter()
-            .map(|item| format!("<li><a href='{}'>{}</a></li>", item.slug, item.title))
+            .map(|item| {
+                let (lang, slug) = item.slug.split_once("/").unwrap_or_default();
+                format!(
+                    "<li><a href='/{lang}/wip/{slug}.html'>{}</a> (<a href='/{lang}/{slug}.pdf' target='_blank'>Preview PDF</a>)</li>",
+                    item.title,
+                    lang = lang,
+                    slug = slug
+                )
+            })
             .collect::<String>();
-        format!("<h2>{}</h2><ul>{}</ul>", title, list_items)
+        format!("<h2 class='filterable-header'>{}</h2><ul class='filterable'>{}</ul>", title, list_items)
     };
 
     let render_translation_list = |title: &str, items: &BTreeMap<String, Vec<String>>| -> String {
@@ -68,7 +79,7 @@ pub fn generate_wip_page(
             .iter()
             .map(|(title, langs)| format!("<li>{} → [{}]</li>", title, langs.join(", ")))
             .collect::<String>();
-        format!("<h2>{}</h2><ul>{}</ul>", title, list_items)
+        format!("<h2 class='filterable-header'>{}</h2><ul class='filterable'>{}</ul>", title, list_items)
     };
 
     let warnings_html = if !warnings.is_empty() {
@@ -82,6 +93,7 @@ pub fn generate_wip_page(
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Work in Progress</title>
     <style>
         body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; margin: 2em; background-color: #fdfdfd; color: #1a1a1a; }}
@@ -94,14 +106,47 @@ pub fn generate_wip_page(
         a:hover {{ text-decoration: underline; }}
         pre {{ background-color: #f0f0f0; padding: 1em; border: 1px solid #ddd; border-radius: 5px; white-space: pre-wrap; word-wrap: break-word; font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace; }}
         code {{ font-size: 0.95em; }}
+        #searchInput {{ width: 100%; padding: 10px; margin-bottom: 20px; font-size: 1em; border-radius: 5px; border: 1px solid #ddd; }}
     </style>
 </head>
 <body>
     <h1>Work in Progress</h1>
+    <input type="text" id="searchInput" onkeyup="searchFunction()" placeholder="Search for articles...">
     {}
     {}
     {}
     {}
+    <script>
+    function searchFunction() {{
+        var input, filter, ul, li, a, i, txtValue;
+        input = document.getElementById('searchInput');
+        filter = input.value.toUpperCase();
+        var lists = document.getElementsByClassName('filterable');
+        for (var j = 0; j < lists.length; j++) {{
+            ul = lists[j];
+            li = ul.getElementsByTagName('li');
+            var header = ul.previousElementSibling;
+            var visibleItems = 0;
+            for (i = 0; i < li.length; i++) {{
+                a = li[i].getElementsByTagName("a")[0];
+                txtValue = a.textContent || a.innerText;
+                if (txtValue.toUpperCase().indexOf(filter) > -1) {{
+                    li[i].style.display = "";
+                    visibleItems++;
+                }} else {{
+                    li[i].style.display = "none";
+                }}
+            }}
+            if (visibleItems > 0) {{
+                header.style.display = "";
+                ul.style.display = "";
+            }} else {{
+                header.style.display = "none";
+                ul.style.display = "none";
+            }}
+        }}
+    }}
+    </script>
 </body>
 </html>
 "#,

--- a/templates/head.html
+++ b/templates/head.html
@@ -72,6 +72,8 @@
     <link rel="alternate" type="text/markdown" href="$$ROOT_HREF$$/$$LANG$$/$$SLUG$$" title="Markdown source of ‘$$TITLE$$’ page">
     <link rel="canonical" href="$$PAGE_HREF$$">
 
+    <!-- ARTICLE_TOOLBAR -->
+
     <link id="favicon" rel="icon" type="image/png" href="$$ROOT_HREF$$/static/img/logo/logo-sm-32.avif">
     <link id="favicon-dark" rel="icon" type="image/png" href="$$ROOT_HREF$$/static/img/logo/logo-sm-32.avif" media="not all">
     <link id="favicon-apple-touch" rel="apple-touch-icon" type="image/png" href="$$ROOT_HREF$$/static/img/logo/logo-sm-192.avif">


### PR DESCRIPTION
This commit introduces several improvements to the build process and user interface for WIP (Work in Progress) articles and documents in the /docs folder.

- Updates the build process to generate PDF and Markdown files for documents in the /docs folder.
- Adds 'Download PDF' and 'Copy Article to Clipboard' buttons to the header of both articles and documents.
- Enhances the 'wip.html' page with a search bar, 'Preview PDF' links for each article, and improved viewport scaling.
- Excludes prayers from the 'wip.html' page to streamline the review process.