### PR TITLE
Fix(pagefind): Correct asset paths in pagefind.html template

### DIFF
--- a/templates/pagefind.html
+++ b/templates/pagefind.html
@@ -2,7 +2,7 @@
 <html lang="$$LANG$$">
 <!-- HEAD_TEMPLATE_HTML -->
 <body class="page-lorem dropcaps-kanzlei">
-    <link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+    <link href="/static/pagefind/pagefind-ui.css" rel="stylesheet">
 	<main>
         <nav id="sidebar">
 			<!-- HEADER_NAVIGATION -->
@@ -17,10 +17,14 @@
             </div>
         </article>
     </main>
-    <script src="/pagefind/pagefind-ui.js"></script>
+    <script src="/static/pagefind/pagefind-ui.js"></script>
     <script>
         window.addEventListener('DOMContentLoaded', (event) => {
-            new PagefindUI({ element: "#search", showSubResults: true });
+            new PagefindUI({
+                element: "#search",
+                showSubResults: true,
+                bundlePath: "/static/pagefind/"
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
The Pagefind UI was failing to load due to incorrect paths for its CSS and JavaScript files, resulting in 404 errors. The search index was also likely failing to load for the same reason.

This commit corrects the paths in `templates/pagefind.html` by prepending `/static` to the URLs for `pagefind-ui.css` and `pagefind-ui.js`. It also adds the `bundlePath` option to the `PagefindUI` constructor to ensure the search index and other assets are loaded from the correct `/static/pagefind/` directory.